### PR TITLE
Add the transformedCheck() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ Here a list of all the functions currently provided by library (namespace omitte
 - `poolCallbacks(...$predicates)` Like `pool()` but accepts an array of predicates
 - `combineMap(array $predicates)` Takes a map of predicates and return a predicates that applies to a map value, returns true when all the predicates return true
 - `poolMap(array $predicates)` Like combineMap, but the returned predicates return `true` when any the predicates returns `true`
+
+### Transforming a value before applying the predicate
+
+- `applyAfter(callable $transformation, callable $predicate)` Returns a predicate
+  which returns the result of the predicate, after it has been applied
+  the the input value, transformed by the `$transformation` function.
+
+#### Example
+
+```php
+use Pentothal as P;
+
+function getYear(DateTime $data)
+{
+    return $data->format('Y');
+}
+
+$datesFrom2016 = array_filter($dates, P\applyAfter('getYear', isSame('2016')));
+
+```
  
 # Quite complex example
 

--- a/pentothal.php
+++ b/pentothal.php
@@ -20,3 +20,4 @@ require_once 'src/contain.php';
 require_once 'src/properties.php';
 require_once 'src/methods.php';
 require_once 'src/map.php';
+require_once 'src/apply_after.php';

--- a/src/apply_after.php
+++ b/src/apply_after.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * This file is part of the Pentothal package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pentothal;
+
+/**
+ * Returns a function which applies a transformation function to it's imput
+ * before testing it with the predicate function.
+ *
+ * @param  callable $transformation
+ * @param  callable $predicate
+ *
+ * @return \Clojure
+ */
+function applyAfter(callable $transformation, callable $predicate)
+{
+    return function ($value) use ($transformation, $predicate) {
+        return $predicate($transformation($value));
+    };
+}

--- a/tests/src/ApplyAfterTest.php
+++ b/tests/src/ApplyAfterTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of the Pentothal package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pentothal\Tests;
+
+use PHPUnit_Framework_TestCase;
+use Pentothal as P;
+
+/**
+ * @license http://opensource.org/licenses/MIT MIT
+ * @package Pentothal
+ */
+final class ApplyAfterTest extends PHPUnit_Framework_TestCase
+{
+    public function testApplyAfter()
+    {
+        $frank = ['name' => 'frank'];
+        $jane  = ['name' => 'jane'];
+
+        $getName = function (array $user) {
+            return $user['name'];
+        };
+
+        $isFrank = P\applyAfter($getName, P\isSame('frank'));
+
+        assertTrue($isFrank($frank));
+        assertFalse($isFrank($jane));
+    }
+}


### PR DESCRIPTION
When used with https://github.com/tomphp/php-transform, this replaces:

``` php
$dates = [ /* array of DateTime objects */ ];

$datesFor2015 = array_filter(
    $dates,
    function (DateTime $date) {
        return $date->format('Y') === '2015';
    }
);
```

with: 

``` php
use Pentathal as P;
use TomPHP\Transform as T;

$dates = [ /* array of DateTime objects */ ];

$datesFor2015 = array_filter(
    $dates,
    P\transformedCheck(T\callMethod('format', 'Y'), P\isSame('2015'))
);
```

Question: is there a better name for this function?
